### PR TITLE
feat(deploy): add config deploy and agent installers

### DIFF
--- a/cmd/clipal/deploy.go
+++ b/cmd/clipal/deploy.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/lansespirit/Clipal/internal/agentinstall"
+	"github.com/lansespirit/Clipal/internal/config"
+	deploypkg "github.com/lansespirit/Clipal/internal/deploy"
+	"github.com/lansespirit/Clipal/internal/integration"
+)
+
+const (
+	defaultDeployPackageName = "clipal.json"
+	deployPackageExt         = ".json"
+)
+
+func runDeploy(args []string) {
+	if len(args) == 0 || (len(args) == 1 && isHelpToken(args[0])) {
+		runDeploySetup(args)
+		return
+	}
+
+	action := strings.TrimSpace(args[0])
+	switch action {
+	case "export":
+		runDeployExport(args[1:])
+	case "import":
+		runDeployImport(args[1:])
+	case "install":
+		runDeploySetup(append([]string{"--skip-takeover"}, args[1:]...))
+	default:
+		runDeploySetup(args)
+	}
+}
+
+func runDeploySetup(args []string) {
+	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		printDeployUsage(os.Stderr)
+	}
+	configDir := fs.String("config-dir", "", "Configuration directory to import into and use for takeover (default: ~/.clipal)")
+	agentsRaw := fs.String("agents", "codex,claude,gemini", "Comma-separated agents to install and takeover")
+	dryRun := fs.Bool("dry-run", false, "Print planned actions without changing the system")
+	skipInstall := fs.Bool("skip-install", false, "Skip installing missing agent CLIs")
+	skipTakeover := fs.Bool("skip-takeover", false, "Skip CLI takeover after install")
+	positionals, flagArgs, err := splitDeploySetupArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy: %v\n", err)
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeployUsage(os.Stdout)
+			return
+		}
+		os.Exit(2)
+	}
+	agents, packagePath, err := resolveDeploySetupInputs(positionals, *agentsRaw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy: %v\n", err)
+		os.Exit(2)
+	}
+
+	cfgDir := *configDir
+	if cfgDir == "" {
+		cfgDir = config.GetConfigDir()
+	}
+
+	if packagePath == "" {
+		if _, err := os.Stat(defaultDeployPackageName); err == nil {
+			packagePath = defaultDeployPackageName
+		} else if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "clipal deploy failed: stat %s: %v\n", defaultDeployPackageName, err)
+			os.Exit(1)
+		}
+	}
+
+	if packagePath != "" {
+		if *dryRun {
+			fmt.Fprintf(os.Stdout, "Would import deploy config: %s -> %s\n", packagePath, cfgDir)
+		} else if err := deploypkg.ImportPackage(deploypkg.ImportOptions{Package: packagePath, ConfigDir: cfgDir}); err != nil {
+			fmt.Fprintf(os.Stderr, "clipal deploy import failed: %v\n", err)
+			os.Exit(1)
+		} else {
+			fmt.Fprintf(os.Stdout, "Imported deploy config: %s -> %s\n", packagePath, cfgDir)
+		}
+	}
+
+	if !*skipInstall {
+		if err := installAgents(agents, *dryRun); err != nil {
+			fmt.Fprintf(os.Stderr, "clipal deploy install failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if !*skipTakeover {
+		targets := make([]string, 0, len(agents))
+		for _, agent := range agents {
+			targets = append(targets, string(agent))
+		}
+		if *dryRun {
+			fmt.Fprintf(os.Stdout, "Would apply takeover: %s\n", strings.Join(targets, ","))
+		} else if err := applyTakeoverTargets(cfgDir, targets); err != nil {
+			fmt.Fprintf(os.Stderr, "clipal deploy takeover failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func splitDeploySetupArgs(args []string) (positionals []string, flagArgs []string, err error) {
+	needsValue := map[string]bool{
+		"config-dir": true,
+		"agents":     true,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "-") {
+			flagArgs = append(flagArgs, a)
+			name := strings.TrimLeft(a, "-")
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				name = name[:eq]
+			}
+			if needsValue[name] && !strings.Contains(a, "=") {
+				if i+1 >= len(args) {
+					return nil, nil, fmt.Errorf("flag %s requires a value", a)
+				}
+				flagArgs = append(flagArgs, args[i+1])
+				i++
+			}
+			continue
+		}
+		positionals = append(positionals, a)
+	}
+	return positionals, flagArgs, nil
+}
+
+func resolveDeploySetupInputs(positionals []string, agentsRaw string) ([]agentinstall.AgentID, string, error) {
+	if len(positionals) == 0 {
+		agents, err := agentinstall.ParseAgents(agentsRaw)
+		return agents, "", err
+	}
+
+	var packagePath string
+	agentTokens := make([]string, 0, len(positionals))
+	for _, positional := range positionals {
+		if _, err := agentinstall.ParseAgent(positional); err == nil {
+			agentTokens = append(agentTokens, positional)
+			continue
+		}
+		if packagePath != "" {
+			return nil, "", fmt.Errorf("unexpected argument %q", positional)
+		}
+		packagePath = positional
+	}
+	if len(agentTokens) == 0 {
+		agents, err := agentinstall.ParseAgents(agentsRaw)
+		return agents, packagePath, err
+	}
+	agents, err := agentinstall.ParseAgents(strings.Join(agentTokens, ","))
+	if err != nil {
+		return nil, "", err
+	}
+	return agents, packagePath, nil
+}
+
+func runDeployExport(args []string) {
+	fs := flag.NewFlagSet("deploy export", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		printDeployUsage(os.Stderr)
+	}
+	output := fs.String("o", "", "Output deploy package path (default: clipal.json)")
+	outputDir := fs.String("output-dir", ".", "Directory for default output package")
+	configDir := fs.String("config-dir", "", "Configuration directory to export (default: ~/.clipal)")
+	takeover := fs.String("include-takeover", "", "Comma-separated takeover targets to include as metadata")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeployUsage(os.Stdout)
+			return
+		}
+		os.Exit(2)
+	}
+	if extra := fs.Args(); len(extra) > 0 {
+		fmt.Fprintf(os.Stderr, "clipal deploy export: unexpected argument %q\n", extra[0])
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	cfgDir := *configDir
+	if cfgDir == "" {
+		cfgDir = config.GetConfigDir()
+	}
+	outputPath, err := normalizeDeployOutputPath(*output, *outputDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy export: %v\n", err)
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	if err := deploypkg.ExportPackage(deploypkg.ExportOptions{
+		ConfigDir:       cfgDir,
+		Output:          outputPath,
+		TakeoverTargets: splitCSV(*takeover),
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy export failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "Deploy package written: %s\n", outputPath)
+	fmt.Fprintln(os.Stdout, "Warning: this package contains provider URLs and API keys.")
+}
+
+func runDeployImport(args []string) {
+	packagePath, flagArgs, err := splitDeployImportArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy import: %v\n", err)
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	fs := flag.NewFlagSet("deploy import", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		printDeployUsage(os.Stderr)
+	}
+	configDir := fs.String("config-dir", "", "Configuration directory to import into (default: ~/.clipal)")
+	temporary := fs.Bool("temporary", false, "Import into an isolated temporary configuration directory")
+	start := fs.Bool("start", false, "Print the command to start Clipal with the imported configuration")
+	takeover := fs.String("takeover", "", "Comma-separated takeover targets to apply after import")
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printDeployUsage(os.Stdout)
+			return
+		}
+		os.Exit(2)
+	}
+	if extra := fs.Args(); len(extra) > 0 {
+		fmt.Fprintf(os.Stderr, "clipal deploy import: unexpected argument %q\n", extra[0])
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+	if strings.TrimSpace(packagePath) == "" {
+		fmt.Fprintln(os.Stderr, "clipal deploy import: package path is required")
+		printDeployUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	cfgDir := *configDir
+	if *temporary {
+		dir, err := os.MkdirTemp("", "clipal-deploy-*")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "clipal deploy import failed: create temporary config dir: %v\n", err)
+			os.Exit(1)
+		}
+		cfgDir = dir
+	} else if cfgDir == "" {
+		cfgDir = config.GetConfigDir()
+	}
+
+	if err := deploypkg.ImportPackage(deploypkg.ImportOptions{
+		Package:   packagePath,
+		ConfigDir: cfgDir,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "clipal deploy import failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "Deploy package imported: %s\n", cfgDir)
+	if *temporary {
+		fmt.Fprintf(os.Stdout, "Temporary config dir: %s\n", cfgDir)
+		fmt.Fprintf(os.Stdout, "Cleanup: rm -rf %s\n", cfgDir)
+	}
+	if targets := splitCSV(*takeover); len(targets) > 0 {
+		if err := applyTakeoverTargets(cfgDir, targets); err != nil {
+			fmt.Fprintf(os.Stderr, "clipal deploy import takeover failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if *start {
+		fmt.Fprintf(os.Stdout, "Start: clipal --config-dir %s\n", cfgDir)
+	}
+}
+
+func printDeployUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage:")
+	fmt.Fprintln(w, "  clipal deploy [<package>] [<agent>...] [--dry-run]")
+	fmt.Fprintln(w, "  clipal install [<agent>...] [--dry-run]")
+	fmt.Fprintln(w, "  clipal deploy export [-o <package>] [--config-dir <dir>]")
+	fmt.Fprintln(w, "  clipal deploy import <package> [--config-dir <dir>] [--temporary] [--start]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "agents:")
+	fmt.Fprintln(w, "  codex, claude, gemini")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "examples:")
+	fmt.Fprintln(w, "  clipal export")
+	fmt.Fprintln(w, "  clipal export -o prod")
+	fmt.Fprintln(w, "  clipal import clipal.json")
+	fmt.Fprintln(w, "  clipal import prod.json --temporary --start")
+	fmt.Fprintln(w, "  clipal deploy")
+	fmt.Fprintln(w, "  clipal deploy codex")
+	fmt.Fprintln(w, "  clipal deploy prod.json codex")
+	fmt.Fprintln(w, "  clipal install codex")
+}
+
+func normalizeDeployOutputPath(output, outputDir string) (string, error) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		dir := strings.TrimSpace(outputDir)
+		if dir == "" {
+			dir = "."
+		}
+		return filepath.Join(dir, defaultDeployPackageName), nil
+	}
+	if strings.HasSuffix(output, deployPackageExt) {
+		return output, nil
+	}
+	if ext := filepath.Ext(output); ext != "" {
+		return "", fmt.Errorf("deploy package path %q must use %s suffix", output, deployPackageExt)
+	}
+	return output + deployPackageExt, nil
+}
+
+func splitDeployImportArgs(args []string) (packagePath string, flagArgs []string, err error) {
+	needsValue := map[string]bool{
+		"config-dir": true,
+		"takeover":   true,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "-") {
+			flagArgs = append(flagArgs, a)
+			name := strings.TrimLeft(a, "-")
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				name = name[:eq]
+			}
+			if needsValue[name] && !strings.Contains(a, "=") {
+				if i+1 >= len(args) {
+					return "", nil, fmt.Errorf("flag %s requires a value", a)
+				}
+				flagArgs = append(flagArgs, args[i+1])
+				i++
+			}
+			continue
+		}
+		if packagePath != "" {
+			return "", nil, fmt.Errorf("unexpected argument %q", a)
+		}
+		packagePath = a
+	}
+	return packagePath, flagArgs, nil
+}
+
+func applyTakeoverTargets(configDir string, targets []string) error {
+	cfg, err := config.Load(configDir)
+	if err != nil {
+		return fmt.Errorf("load imported config: %w", err)
+	}
+	mgr := integration.NewManager(configDir)
+	for _, target := range targets {
+		product, err := parseTakeoverTarget(target)
+		if err != nil {
+			return err
+		}
+		result, err := mgr.Apply(product, cfg)
+		if err != nil {
+			return fmt.Errorf("%s: %w", target, err)
+		}
+		fmt.Fprintf(os.Stdout, "Takeover applied: %s (%s)\n", result.Product, result.Message)
+	}
+	return nil
+}
+
+func installAgents(agents []agentinstall.AgentID, dryRun bool) error {
+	for _, agent := range agents {
+		plan, err := agentinstall.PlanForAgent(agent, runtime.GOOS)
+		if err != nil {
+			return err
+		}
+		if _, err := exec.LookPath(plan.CheckCommand); err == nil {
+			fmt.Fprintf(os.Stdout, "Agent already installed: %s\n", agent)
+			continue
+		}
+		if dryRun {
+			fmt.Fprintf(os.Stdout, "Would install %s: %s\n", agent, shellCommandString(plan.InstallCommand))
+			continue
+		}
+		if err := ensureInstallerAvailable(plan.InstallCommand[0]); err != nil {
+			return fmt.Errorf("%s: %w", agent, err)
+		}
+		fmt.Fprintf(os.Stdout, "Installing %s: %s\n", agent, shellCommandString(plan.InstallCommand))
+		cmd := exec.Command(plan.InstallCommand[0], plan.InstallCommand[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s install command failed: %w", agent, err)
+		}
+	}
+	return nil
+}
+
+func ensureInstallerAvailable(command string) error {
+	if _, err := exec.LookPath(command); err != nil {
+		return fmt.Errorf("%s is required to run the official install command", command)
+	}
+	return nil
+}
+
+func parseTakeoverTarget(target string) (integration.ProductID, error) {
+	switch strings.TrimSpace(strings.ToLower(target)) {
+	case "claude", "claude-code", "claudecode":
+		return integration.ProductClaudeCode, nil
+	case "codex", "codex-cli":
+		return integration.ProductCodexCLI, nil
+	case "opencode", "open-code":
+		return integration.ProductOpenCode, nil
+	case "gemini", "gemini-cli":
+		return integration.ProductGeminiCLI, nil
+	case "continue":
+		return integration.ProductContinue, nil
+	case "aider":
+		return integration.ProductAider, nil
+	case "goose":
+		return integration.ProductGoose, nil
+	default:
+		return "", fmt.Errorf("unknown takeover target %q", target)
+	}
+}
+
+func shellCommandString(parts []string) string {
+	if len(parts) == 3 && (parts[0] == "sh" || parts[0] == "bash") && parts[1] == "-c" {
+		return parts[2]
+	}
+	return strings.Join(parts, " ")
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/cmd/clipal/main.go
+++ b/cmd/clipal/main.go
@@ -33,6 +33,7 @@ const (
 	rootCommandUpdate      rootCommand = "update"
 	rootCommandStatus      rootCommand = "status"
 	rootCommandService     rootCommand = "service"
+	rootCommandDeploy      rootCommand = "deploy"
 	rootCommandApplyUpdate rootCommand = "__apply-update"
 )
 
@@ -73,6 +74,9 @@ func main() {
 	case rootCommandService:
 		runService(args)
 		return
+	case rootCommandDeploy:
+		runDeploy(args)
+		return
 	case rootCommandApplyUpdate:
 		runApplyUpdate(args)
 		return
@@ -99,6 +103,14 @@ func resolveRootCommand(args []string) (rootCommand, []string, error) {
 		return rootCommandStatus, args[1:], nil
 	case "service":
 		return rootCommandService, args[1:], nil
+	case "deploy":
+		return rootCommandDeploy, args[1:], nil
+	case "export":
+		return rootCommandDeploy, append([]string{"export"}, args[1:]...), nil
+	case "import":
+		return rootCommandDeploy, append([]string{"import"}, args[1:]...), nil
+	case "install":
+		return rootCommandDeploy, append([]string{"install"}, args[1:]...), nil
 	case "__apply-update":
 		return rootCommandApplyUpdate, args[1:], nil
 	case "restart":
@@ -119,6 +131,10 @@ func printRootUsage(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  status            Show runtime and service status without starting the server")
 	fmt.Fprintln(w, "  service           Install and manage the background service")
+	fmt.Fprintln(w, "  deploy            Import config and install/takeover selected AI CLIs")
+	fmt.Fprintln(w, "  export            Shortcut for 'clipal deploy export'")
+	fmt.Fprintln(w, "  import            Shortcut for 'clipal deploy import'")
+	fmt.Fprintln(w, "  install           Install selected AI CLI without takeover")
 	fmt.Fprintln(w, "  update            Check for updates or replace the current binary in place")
 	fmt.Fprintln(w, "  restart           Shortcut for 'clipal service restart'")
 	fmt.Fprintln(w, "  help              Show this help")
@@ -142,6 +158,10 @@ func printRootUsage(w io.Writer) {
 	fmt.Fprintln(w, "  clipal status")
 	fmt.Fprintln(w, "  clipal restart")
 	fmt.Fprintln(w, "  clipal service install")
+	fmt.Fprintln(w, "  clipal export")
+	fmt.Fprintln(w, "  clipal import clipal.json")
+	fmt.Fprintln(w, "  clipal deploy codex")
+	fmt.Fprintln(w, "  clipal install codex")
 	fmt.Fprintln(w, "  clipal update")
 }
 

--- a/cmd/clipal/main_test.go
+++ b/cmd/clipal/main_test.go
@@ -33,9 +33,17 @@ func resetForMainTest() {
 
 func runMainHelper(t *testing.T, args ...string) (string, int) {
 	t.Helper()
+	return runMainHelperInDir(t, "", args...)
+}
+
+func runMainHelperInDir(t *testing.T, dir string, args ...string) (string, int) {
+	t.Helper()
 
 	//nolint:gosec // Tests intentionally re-exec the current test binary as a helper process.
 	cmd := exec.Command(os.Args[0], "-test.run=TestMainHelperProcess")
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	cmd.Env = append(os.Environ(),
 		"CLIPAL_MAIN_HELPER=1",
 		"CLIPAL_MAIN_ARGS="+strings.Join(args, "\n"),
@@ -163,6 +171,30 @@ func TestResolveRootCommand(t *testing.T) {
 			wantArgs: []string{"restart"},
 		},
 		{
+			name:     "DeployCommandPassesThrough",
+			args:     []string{"deploy", "export", "-o", "prod.json"},
+			wantCmd:  rootCommandDeploy,
+			wantArgs: []string{"export", "-o", "prod.json"},
+		},
+		{
+			name:     "ExportAliasRoutesToDeployExport",
+			args:     []string{"export"},
+			wantCmd:  rootCommandDeploy,
+			wantArgs: []string{"export"},
+		},
+		{
+			name:     "ImportAliasRoutesToDeployImport",
+			args:     []string{"import", "clipal.json"},
+			wantCmd:  rootCommandDeploy,
+			wantArgs: []string{"import", "clipal.json"},
+		},
+		{
+			name:     "InstallAliasRoutesToDeployInstall",
+			args:     []string{"install", "codex"},
+			wantCmd:  rootCommandDeploy,
+			wantArgs: []string{"install", "codex"},
+		},
+		{
 			name:    "HelpTokenShowsRootHelp",
 			args:    []string{"help"},
 			wantCmd: rootCommandHelp,
@@ -212,9 +244,306 @@ func TestMainHelpFlagShowsCommands(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, out=%s", code, out)
 	}
-	if !strings.Contains(out, "Commands:") || !strings.Contains(out, "clipal restart") {
+	if !strings.Contains(out, "Commands:") || !strings.Contains(out, "clipal restart") || !strings.Contains(out, "deploy") {
 		t.Fatalf("unexpected help output: %s", out)
 	}
+}
+
+func TestDeployExportImportCLI(t *testing.T) {
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+	if err := os.WriteFile(filepath.Join(src, "gemini.yaml"), []byte("mode: auto\nproviders: []\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile gemini.yaml: %v", err)
+	}
+
+	packagePath := filepath.Join(t.TempDir(), "prod.json")
+	out, code := runMainHelper(t, "deploy", "export", "-o", packagePath, "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("export exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "Deploy package written:") {
+		t.Fatalf("unexpected export output: %s", out)
+	}
+
+	dst := t.TempDir()
+	out, code = runMainHelper(t, "deploy", "import", packagePath, "--config-dir", dst)
+	if code != 0 {
+		t.Fatalf("import exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "Deploy package imported:") {
+		t.Fatalf("unexpected import output: %s", out)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "openai.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile openai.yaml: %v", err)
+	}
+	if !strings.Contains(string(got), "api_key: key1") {
+		t.Fatalf("imported openai.yaml did not include secret: %s", got)
+	}
+}
+
+func TestDeployExportDefaultOutputAndFixedSuffix(t *testing.T) {
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+	outDir := t.TempDir()
+
+	out, code := runMainHelper(t, "deploy", "export", "--config-dir", src, "--output-dir", outDir)
+	if code != 0 {
+		t.Fatalf("default export exit code = %d, out=%s", code, out)
+	}
+	defaultPackage := filepath.Join(outDir, "clipal.json")
+	if _, err := os.Stat(defaultPackage); err != nil {
+		t.Fatalf("expected default package %s: %v", defaultPackage, err)
+	}
+	if !strings.Contains(out, defaultPackage) {
+		t.Fatalf("default package path missing from output:\n%s", out)
+	}
+
+	out, code = runMainHelper(t, "deploy", "export", "-o", filepath.Join(outDir, "prod"), "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("suffix append export exit code = %d, out=%s", code, out)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "prod.json")); err != nil {
+		t.Fatalf("expected suffixed package: %v", err)
+	}
+
+	out, code = runMainHelper(t, "deploy", "export", "-o", filepath.Join(outDir, "prod.conf"), "--config-dir", src)
+	if code != 2 {
+		t.Fatalf("wrong suffix exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "must use .json") {
+		t.Fatalf("expected fixed suffix error, out=%s", out)
+	}
+}
+
+func TestDeployImportRootAlias(t *testing.T) {
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+
+	packagePath := filepath.Join(t.TempDir(), "clipal.json")
+	out, code := runMainHelper(t, "export", "-o", packagePath, "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("export alias exit code = %d, out=%s", code, out)
+	}
+
+	dst := t.TempDir()
+	out, code = runMainHelper(t, "import", packagePath, "--config-dir", dst)
+	if code != 0 {
+		t.Fatalf("import alias exit code = %d, out=%s", code, out)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "openai.yaml")); err != nil {
+		t.Fatalf("import alias should restore openai.yaml: %v", err)
+	}
+}
+
+func TestDeployImportTemporary(t *testing.T) {
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+
+	packagePath := filepath.Join(t.TempDir(), "prod.json")
+	out, code := runMainHelper(t, "deploy", "export", "-o", packagePath, "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("export exit code = %d, out=%s", code, out)
+	}
+
+	normalTarget := t.TempDir()
+	out, code = runMainHelper(t, "deploy", "import", packagePath, "--config-dir", normalTarget, "--temporary")
+	if code != 0 {
+		t.Fatalf("temporary import exit code = %d, out=%s", code, out)
+	}
+	tmpDir := extractOutputValue(t, out, "Temporary config dir:")
+	if tmpDir == "" || tmpDir == normalTarget {
+		t.Fatalf("unexpected temporary config dir %q in output:\n%s", tmpDir, out)
+	}
+	if !strings.Contains(out, "Cleanup: rm -rf ") {
+		t.Fatalf("missing cleanup hint in output:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(normalTarget, "openai.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("temporary import should not write normal config dir, err=%v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(tmpDir, "openai.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile temporary openai.yaml: %v", err)
+	}
+	if !strings.Contains(string(got), "api_key: key1") {
+		t.Fatalf("temporary import did not include secret: %s", got)
+	}
+	_ = os.RemoveAll(tmpDir)
+}
+
+func TestDeployImportAppliesTakeover(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	src := t.TempDir()
+	writeMainConfig(t, src, 4567, "")
+
+	packagePath := filepath.Join(t.TempDir(), "prod.json")
+	out, code := runMainHelper(t, "deploy", "export", "-o", packagePath, "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("export exit code = %d, out=%s", code, out)
+	}
+
+	dst := t.TempDir()
+	out, code = runMainHelper(t, "deploy", "import", packagePath, "--config-dir", dst, "--takeover", "codex")
+	if code != 0 {
+		t.Fatalf("import exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "Takeover applied: codex") {
+		t.Fatalf("missing takeover output:\n%s", out)
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile codex config: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `model_provider = 'clipal'`) && !strings.Contains(body, `model_provider = "clipal"`) {
+		t.Fatalf("codex config missing model_provider:\n%s", body)
+	}
+	if !strings.Contains(body, "http://127.0.0.1:4567/clipal") {
+		t.Fatalf("codex config missing imported Clipal base URL:\n%s", body)
+	}
+}
+
+func TestDeployDryRunShowsOfficialInstallCommands(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	out, code := runMainHelper(t, "deploy", "--dry-run", "--agents", "codex,claude,gemini")
+	if code != 0 {
+		t.Fatalf("deploy dry-run exit code = %d, out=%s", code, out)
+	}
+	for _, want := range []string{
+		"curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+		"curl -fsSL https://claude.ai/install.sh | bash",
+		"npm install -g @google/gemini-cli",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestShellCommandStringShowsOfficialPipelineCommand(t *testing.T) {
+	t.Parallel()
+
+	got := shellCommandString([]string{"sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"})
+	want := "curl -fsSL https://chatgpt.com/codex/install.sh | sh"
+	if got != want {
+		t.Fatalf("shellCommandString = %q, want %q", got, want)
+	}
+}
+
+func TestDeployPositionalAgentDryRun(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	out, code := runMainHelper(t, "deploy", "codex", "--dry-run")
+	if code != 0 {
+		t.Fatalf("deploy codex dry-run exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "curl -fsSL https://chatgpt.com/codex/install.sh | sh") {
+		t.Fatalf("codex install command missing:\n%s", out)
+	}
+	if strings.Contains(out, "@anthropic-ai/claude-code") || strings.Contains(out, "@google/gemini-cli") {
+		t.Fatalf("deploy codex should not include other agents:\n%s", out)
+	}
+	if !strings.Contains(out, "Would apply takeover: codex") {
+		t.Fatalf("deploy codex should include takeover:\n%s", out)
+	}
+}
+
+func TestDeployPackageAndPositionalAgentDryRun(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+	packagePath := filepath.Join(t.TempDir(), "prod.json")
+	out, code := runMainHelper(t, "export", "-o", packagePath, "--config-dir", src)
+	if code != 0 {
+		t.Fatalf("export exit code = %d, out=%s", code, out)
+	}
+
+	dst := t.TempDir()
+	out, code = runMainHelper(t, "deploy", packagePath, "codex", "--config-dir", dst, "--dry-run")
+	if code != 0 {
+		t.Fatalf("deploy package codex dry-run exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "Would import deploy config: "+packagePath+" -> "+dst) {
+		t.Fatalf("deploy should import the explicit package:\n%s", out)
+	}
+	if !strings.Contains(out, "curl -fsSL https://chatgpt.com/codex/install.sh | sh") {
+		t.Fatalf("codex install command missing:\n%s", out)
+	}
+	if strings.Contains(out, "claude.ai/install.sh") || strings.Contains(out, "@google/gemini-cli") {
+		t.Fatalf("explicit codex deploy should not include other agents:\n%s", out)
+	}
+	if !strings.Contains(out, "Would apply takeover: codex") {
+		t.Fatalf("deploy package codex should include codex takeover:\n%s", out)
+	}
+}
+
+func TestInstallAliasInstallsOnlySelectedAgent(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	out, code := runMainHelper(t, "install", "codex", "--dry-run")
+	if code != 0 {
+		t.Fatalf("install codex dry-run exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "curl -fsSL https://chatgpt.com/codex/install.sh | sh") {
+		t.Fatalf("codex install command missing:\n%s", out)
+	}
+	if strings.Contains(out, "Would apply takeover") {
+		t.Fatalf("install alias should not apply takeover:\n%s", out)
+	}
+}
+
+func TestDeployHelpShowsAgentCommands(t *testing.T) {
+	out, code := runMainHelper(t, "deploy", "--help")
+	if code != 0 {
+		t.Fatalf("deploy help exit code = %d, out=%s", code, out)
+	}
+	for _, want := range []string{
+		"clipal deploy codex",
+		"clipal install codex",
+		"clipal deploy prod.json codex",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("deploy help missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDeployImportsDefaultPackageFromCurrentDirectory(t *testing.T) {
+	src := t.TempDir()
+	writeMainConfig(t, src, 3333, "")
+
+	workDir := t.TempDir()
+	out, code := runMainHelper(t, "export", "--config-dir", src, "--output-dir", workDir)
+	if code != 0 {
+		t.Fatalf("export exit code = %d, out=%s", code, out)
+	}
+
+	dst := t.TempDir()
+	out, code = runMainHelperInDir(t, workDir, "deploy", "--config-dir", dst, "--skip-install", "--skip-takeover")
+	if code != 0 {
+		t.Fatalf("deploy exit code = %d, out=%s", code, out)
+	}
+	if !strings.Contains(out, "Imported deploy config:") {
+		t.Fatalf("deploy should import default package:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "openai.yaml")); err != nil {
+		t.Fatalf("deploy should restore openai.yaml: %v", err)
+	}
+}
+
+func extractOutputValue(t *testing.T, out, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		}
+	}
+	t.Fatalf("missing output prefix %q in:\n%s", prefix, out)
+	return ""
 }
 
 func TestMainServiceHelpShowsUsage(t *testing.T) {

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -14,6 +14,7 @@ English: [docs/en/README.md](README.md) | 中文: [docs/zh/README.md](../zh/READ
 - [Getting Started](getting-started.md)
 - [Client Setup](client-setup.md)
 - [Config Reference](config-reference.md)
+- [Deploy Packages](deploy.md)
 - [Web UI Guide](web-ui.md)
 - [Routing and Failover](routing-and-failover.md)
 - [Services, Status, and Updates](services.md)

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -1,0 +1,129 @@
+# Deploy Packages
+
+Deploy packages move a working Clipal configuration from one machine to another.
+
+Use this when you have already configured providers locally and want another machine to use the same provider URLs, API keys, routing, and global settings without opening the Web UI or re-entering secrets.
+
+## Export
+
+```bash
+clipal export
+```
+
+By default this reads the normal Clipal config directory (`~/.clipal`) and writes `clipal.json` in the current directory.
+
+To choose a package name, pass `-o`. If the name has no suffix, Clipal appends `.json`; if it has another suffix, Clipal rejects it.
+
+```bash
+clipal export -o prod
+```
+
+To export a different config directory:
+
+```bash
+clipal export -o prod --config-dir /path/to/config
+```
+
+The package contains provider URLs and API keys. Treat it like a secret file.
+
+## Normal Import
+
+```bash
+clipal import clipal.json
+```
+
+This writes the packaged config files into the normal Clipal config directory on the current machine.
+
+To import into a specific directory:
+
+```bash
+clipal import prod.json --config-dir /path/to/config
+```
+
+To apply CLI takeover during import:
+
+```bash
+clipal import prod.json --takeover claude,codex,gemini
+```
+
+After import, start or restart Clipal using the existing service commands:
+
+```bash
+clipal service install --config-dir /path/to/config
+clipal service restart
+```
+
+## Temporary Import
+
+```bash
+clipal import prod.json --temporary
+```
+
+Temporary import creates a separate temporary config directory and writes the packaged files there. It does not overwrite the normal Clipal config directory.
+
+The command prints the temporary directory and a cleanup command. Secrets are still written to that temporary directory, so stop any Clipal process using it before cleanup.
+
+To run Clipal with the temporary config:
+
+```bash
+clipal --config-dir /tmp/clipal-deploy-...
+```
+
+`--start` currently prints the start command for the imported directory instead of installing or restarting a service.
+
+`--takeover` reuses Clipal's existing CLI Takeover implementation and supports `claude`, `codex`, `opencode`, `gemini`, `continue`, `aider`, and `goose`.
+
+## One-Command Agent Deploy
+
+After installing Clipal on a new machine, put `clipal.json` in the current directory and run:
+
+```bash
+clipal deploy
+```
+
+This command:
+
+1. Imports `clipal.json` if it exists in the current directory.
+2. Checks whether `codex`, `claude`, and `gemini` are installed.
+3. Runs the official install command for any missing CLI.
+4. Applies Clipal's existing CLI Takeover for Codex, Claude Code, and Gemini CLI.
+
+To preview the commands without changing the machine:
+
+```bash
+clipal deploy --dry-run
+```
+
+To deploy only selected agents:
+
+```bash
+clipal deploy codex
+clipal deploy claude gemini
+```
+
+To install an official CLI without applying Clipal takeover:
+
+```bash
+clipal install codex
+clipal install claude
+clipal install gemini
+```
+
+`clipal deploy <agent>` installs the selected agent and applies Clipal's existing one-click takeover.
+
+`clipal install <agent>` only runs the official install command and does not change agent configuration.
+
+The comma-separated form still works:
+
+```bash
+clipal deploy --agents codex,claude
+```
+
+Clipal does not replace the upstream installers. It executes the official install commands directly and fails clearly if required tools such as `bash`, `npm`, `sh`, `curl`, or `powershell` are missing.
+
+## Safety Notes
+
+- Deploy packages include API keys by design.
+- Only move them to machines you trust.
+- Import rejects filenames outside Clipal's known config file list.
+- Existing Clipal config schema and routing behavior are unchanged.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -14,6 +14,7 @@ English: [docs/en/README.md](../en/README.md) | 中文: [docs/zh/README.md](READ
 - [快速开始](getting-started.md)
 - [客户端接入](client-setup.md)
 - [配置参考](config-reference.md)
+- [部署包](deploy.md)
 - [Web UI 使用说明](web-ui.md)
 - [路由与故障切换](routing-and-failover.md)
 - [后台服务、状态与更新](services.md)

--- a/docs/zh/deploy.md
+++ b/docs/zh/deploy.md
@@ -1,0 +1,129 @@
+# 部署包
+
+部署包用于把一台机器上已经可用的 Clipal 配置迁移到另一台机器。
+
+当你已经在本地配置好了 provider，希望另一台机器直接复用同一套 provider URL、API Key、路由和全局设置时，可以使用部署包。目标是不打开 Web UI，也不重新手动输入密钥。
+
+## 导出
+
+```bash
+clipal export
+```
+
+默认会读取普通 Clipal 配置目录（`~/.clipal`），并在当前目录写出 `clipal.json`。
+
+如果要指定包名，传 `-o`。没有后缀时，Clipal 会自动补 `.json`；如果传了其他后缀，Clipal 会拒绝。
+
+```bash
+clipal export -o prod
+```
+
+如果要导出指定配置目录：
+
+```bash
+clipal export -o prod --config-dir /path/to/config
+```
+
+部署包会包含 provider URL 和 API Key。请把它当作敏感文件处理。
+
+## 普通导入
+
+```bash
+clipal import clipal.json
+```
+
+普通导入会把包里的配置文件写入当前机器的 Clipal 配置目录。
+
+如果要导入到指定目录：
+
+```bash
+clipal import prod.json --config-dir /path/to/config
+```
+
+如果导入时要同时执行 CLI Takeover：
+
+```bash
+clipal import prod.json --takeover claude,codex,gemini
+```
+
+导入后，用现有 service 命令启动或重启 Clipal：
+
+```bash
+clipal service install --config-dir /path/to/config
+clipal service restart
+```
+
+## 临时导入
+
+```bash
+clipal import prod.json --temporary
+```
+
+临时导入会创建一个独立的临时配置目录，并把部署包里的文件写到那里。它不会覆盖普通 Clipal 配置目录。
+
+命令会输出临时目录和 cleanup 命令。密钥仍然会写入这个临时目录，所以清理前需要先停止正在使用该目录的 Clipal 进程。
+
+使用临时配置运行 Clipal：
+
+```bash
+clipal --config-dir /tmp/clipal-deploy-...
+```
+
+当前版本中，`--start` 只会打印对应的启动命令，不会自动安装或重启系统服务。
+
+`--takeover` 会复用 Clipal 现有的一键接管实现，支持 `claude`、`codex`、`opencode`、`gemini`、`continue`、`aider` 和 `goose`。
+
+## 一条命令部署 Agent
+
+在新机器上安装好 Clipal 后，把 `clipal.json` 放到当前目录，然后执行：
+
+```bash
+clipal deploy
+```
+
+这个命令会：
+
+1. 如果当前目录存在 `clipal.json`，先导入它。
+2. 检查 `codex`、`claude`、`gemini` 是否已经安装。
+3. 对缺失的 CLI 执行官方安装命令。
+4. 调用 Clipal 现有的一键接管，把 Codex、Claude Code、Gemini CLI 指向 Clipal。
+
+如果只想预览，不修改机器：
+
+```bash
+clipal deploy --dry-run
+```
+
+如果只部署部分 Agent：
+
+```bash
+clipal deploy codex
+clipal deploy claude gemini
+```
+
+如果只想安装官方 CLI，不做 Clipal Takeover：
+
+```bash
+clipal install codex
+clipal install claude
+clipal install gemini
+```
+
+`clipal deploy <agent>` = 安装所选 Agent，并调用 Clipal 现有的一键接管。
+
+`clipal install <agent>` = 只执行官方安装命令，不修改 Agent 配置。
+
+也可以继续使用逗号参数：
+
+```bash
+clipal deploy --agents codex,claude
+```
+
+Clipal 不替换上游安装器。它只会直接执行官方安装命令；如果缺少 `bash`、`npm`、`sh`、`curl` 或 `powershell` 等官方命令依赖，会明确报错。
+
+## 安全说明
+
+- 部署包按设计会包含 API Key。
+- 只把部署包移动到你信任的机器。
+- 导入会拒绝不属于 Clipal 配置文件清单的文件名。
+- 现有 Clipal 配置格式和路由行为不变。

--- a/internal/agentinstall/plan.go
+++ b/internal/agentinstall/plan.go
@@ -1,0 +1,92 @@
+package agentinstall
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AgentID string
+
+const (
+	AgentCodex  AgentID = "codex"
+	AgentClaude AgentID = "claude"
+	AgentGemini AgentID = "gemini"
+)
+
+type Plan struct {
+	Agent          AgentID
+	CheckCommand   string
+	InstallCommand []string
+}
+
+func DefaultAgents() []AgentID {
+	return []AgentID{AgentCodex, AgentClaude, AgentGemini}
+}
+
+func PlanForAgent(agent AgentID, goos string) (Plan, error) {
+	switch agent {
+	case AgentCodex:
+		if goos == "windows" {
+			return Plan{
+				Agent:          AgentCodex,
+				CheckCommand:   "codex",
+				InstallCommand: []string{"powershell", "-ExecutionPolicy", "ByPass", "-c", "irm https://chatgpt.com/codex/install.ps1 | iex"},
+			}, nil
+		}
+		return Plan{
+			Agent:          AgentCodex,
+			CheckCommand:   "codex",
+			InstallCommand: []string{"sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"},
+		}, nil
+	case AgentClaude:
+		if goos == "windows" {
+			return Plan{
+				Agent:          AgentClaude,
+				CheckCommand:   "claude",
+				InstallCommand: []string{"powershell", "-Command", "irm https://claude.ai/install.ps1 | iex"},
+			}, nil
+		}
+		return Plan{
+			Agent:          AgentClaude,
+			CheckCommand:   "claude",
+			InstallCommand: []string{"bash", "-c", "curl -fsSL https://claude.ai/install.sh | bash"},
+		}, nil
+	case AgentGemini:
+		return Plan{
+			Agent:          AgentGemini,
+			CheckCommand:   "gemini",
+			InstallCommand: []string{"npm", "install", "-g", "@google/gemini-cli"},
+		}, nil
+	default:
+		return Plan{}, fmt.Errorf("unknown agent %q", agent)
+	}
+}
+
+func ParseAgents(raw string) ([]AgentID, error) {
+	if strings.TrimSpace(raw) == "" {
+		return DefaultAgents(), nil
+	}
+	parts := strings.Split(raw, ",")
+	agents := make([]AgentID, 0, len(parts))
+	for _, part := range parts {
+		agent, err := ParseAgent(part)
+		if err != nil {
+			return nil, err
+		}
+		agents = append(agents, agent)
+	}
+	return agents, nil
+}
+
+func ParseAgent(raw string) (AgentID, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "codex", "codex-cli":
+		return AgentCodex, nil
+	case "claude", "claude-code", "claudecode":
+		return AgentClaude, nil
+	case "gemini", "gemini-cli":
+		return AgentGemini, nil
+	default:
+		return "", fmt.Errorf("unknown agent %q", raw)
+	}
+}

--- a/internal/agentinstall/plan_test.go
+++ b/internal/agentinstall/plan_test.go
@@ -1,0 +1,85 @@
+package agentinstall
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPlanForAgentUsesOfficialInstallCommands(t *testing.T) {
+	tests := []struct {
+		name      string
+		agent     AgentID
+		goos      string
+		wantCheck string
+		wantCmd   []string
+	}{
+		{
+			name:      "CodexUnix",
+			agent:     AgentCodex,
+			goos:      "linux",
+			wantCheck: "codex",
+			wantCmd:   []string{"sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"},
+		},
+		{
+			name:      "CodexWindows",
+			agent:     AgentCodex,
+			goos:      "windows",
+			wantCheck: "codex",
+			wantCmd:   []string{"powershell", "-ExecutionPolicy", "ByPass", "-c", "irm https://chatgpt.com/codex/install.ps1 | iex"},
+		},
+		{
+			name:      "Claude",
+			agent:     AgentClaude,
+			goos:      "linux",
+			wantCheck: "claude",
+			wantCmd:   []string{"bash", "-c", "curl -fsSL https://claude.ai/install.sh | bash"},
+		},
+		{
+			name:      "ClaudeWindows",
+			agent:     AgentClaude,
+			goos:      "windows",
+			wantCheck: "claude",
+			wantCmd:   []string{"powershell", "-Command", "irm https://claude.ai/install.ps1 | iex"},
+		},
+		{
+			name:      "Gemini",
+			agent:     AgentGemini,
+			goos:      "linux",
+			wantCheck: "gemini",
+			wantCmd:   []string{"npm", "install", "-g", "@google/gemini-cli"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := PlanForAgent(tt.agent, tt.goos)
+			if err != nil {
+				t.Fatalf("PlanForAgent: %v", err)
+			}
+			if got.CheckCommand != tt.wantCheck {
+				t.Fatalf("CheckCommand = %q, want %q", got.CheckCommand, tt.wantCheck)
+			}
+			if !reflect.DeepEqual(got.InstallCommand, tt.wantCmd) {
+				t.Fatalf("InstallCommand = %#v, want %#v", got.InstallCommand, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestParseAgents(t *testing.T) {
+	got, err := ParseAgents("codex,claude-code,gemini-cli")
+	if err != nil {
+		t.Fatalf("ParseAgents: %v", err)
+	}
+	want := []AgentID{AgentCodex, AgentClaude, AgentGemini}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("agents = %#v, want %#v", got, want)
+	}
+
+	if _, err := ParseAgents("codex,nope"); err == nil {
+		t.Fatalf("expected unknown agent error")
+	}
+}

--- a/internal/deploy/package.go
+++ b/internal/deploy/package.go
@@ -1,0 +1,157 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lansespirit/Clipal/internal/config"
+)
+
+const (
+	ManifestName   = "manifest.json"
+	PackageVersion = 1
+)
+
+type Manifest struct {
+	Version         int               `json:"version"`
+	CreatedBy       string            `json:"created_by"`
+	CreatedAt       string            `json:"created_at,omitempty"`
+	ContainsSecrets bool              `json:"contains_secrets"`
+	ConfigFiles     map[string]string `json:"config_files"`
+	TakeoverTargets []string          `json:"takeover_targets,omitempty"`
+}
+
+type ExportOptions struct {
+	ConfigDir       string
+	Output          string
+	TakeoverTargets []string
+}
+
+type ImportOptions struct {
+	Package   string
+	ConfigDir string
+}
+
+func ExportPackage(opts ExportOptions) error {
+	if strings.TrimSpace(opts.ConfigDir) == "" {
+		return fmt.Errorf("config dir is required")
+	}
+	if strings.TrimSpace(opts.Output) == "" {
+		return fmt.Errorf("output path is required")
+	}
+
+	configFiles := make(map[string]string, len(config.WatchedConfigFilenames()))
+	for _, name := range config.WatchedConfigFilenames() {
+		src := filepath.Join(opts.ConfigDir, name)
+		info, err := os.Stat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat %s: %w", name, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", name)
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		configFiles[name] = string(data)
+	}
+
+	manifest := Manifest{
+		Version:         PackageVersion,
+		CreatedBy:       "clipal",
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		ContainsSecrets: true,
+		ConfigFiles:     configFiles,
+		TakeoverTargets: append([]string(nil), opts.TakeoverTargets...),
+	}
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	manifestData = append(manifestData, '\n')
+	if err := os.MkdirAll(filepath.Dir(opts.Output), 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.WriteFile(opts.Output, manifestData, 0o600); err != nil {
+		return fmt.Errorf("write package: %w", err)
+	}
+	return nil
+}
+
+func ImportPackage(opts ImportOptions) error {
+	if strings.TrimSpace(opts.Package) == "" {
+		return fmt.Errorf("package path is required")
+	}
+	if strings.TrimSpace(opts.ConfigDir) == "" {
+		return fmt.Errorf("config dir is required")
+	}
+
+	data, err := os.ReadFile(opts.Package)
+	if err != nil {
+		return fmt.Errorf("read package: %w", err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("decode deploy package: %w", err)
+	}
+	if err := validateManifest(manifest); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(opts.ConfigDir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	for name, content := range manifest.ConfigFiles {
+		if err := validateConfigFilename(name); err != nil {
+			return err
+		}
+		dst := filepath.Join(opts.ConfigDir, name)
+		if err := os.WriteFile(dst, []byte(content), 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func validateManifest(manifest Manifest) error {
+	if manifest.Version != PackageVersion {
+		return fmt.Errorf("unsupported deploy package version %d", manifest.Version)
+	}
+	if strings.TrimSpace(manifest.CreatedBy) != "clipal" {
+		return fmt.Errorf("unsupported deploy package creator %q", manifest.CreatedBy)
+	}
+	if manifest.ConfigFiles == nil {
+		return fmt.Errorf("package missing config_files")
+	}
+	for name := range manifest.ConfigFiles {
+		if err := validateConfigFilename(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConfigFilename(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("unsafe config filename %q", name)
+	}
+	if strings.ContainsAny(name, `/\`) || filepath.IsAbs(name) || filepath.Clean(name) != name {
+		return fmt.Errorf("unsafe config filename %q", name)
+	}
+	for _, allowed := range config.WatchedConfigFilenames() {
+		if name == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsafe config filename %q", name)
+}

--- a/internal/deploy/package_test.go
+++ b/internal/deploy/package_test.go
@@ -1,0 +1,115 @@
+package deploy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestConfigFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(strings.TrimSpace(body)+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", name, err)
+	}
+}
+
+func readPackageJSON(t *testing.T, packagePath string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		t.Fatalf("ReadFile package: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal package JSON: %v\n%s", err, data)
+	}
+	return out
+}
+
+func TestExportImportPackagePreservesConfigFiles(t *testing.T) {
+	src := t.TempDir()
+	writeTestConfigFile(t, src, "config.yaml", `
+listen_addr: 127.0.0.1
+port: 3333
+`)
+	writeTestConfigFile(t, src, "openai.yaml", `
+mode: auto
+providers:
+  - name: primary
+    base_url: https://api.example.com
+    api_key: sk-secret
+    priority: 1
+`)
+	writeTestConfigFile(t, src, "gemini.yaml", `
+mode: auto
+providers: []
+`)
+
+	packagePath := filepath.Join(t.TempDir(), "prod.json")
+	if err := ExportPackage(ExportOptions{
+		ConfigDir: src,
+		Output:    packagePath,
+	}); err != nil {
+		t.Fatalf("ExportPackage: %v", err)
+	}
+
+	payload := readPackageJSON(t, packagePath)
+	if payload["contains_secrets"] != true {
+		t.Fatalf("package does not mark secrets: %#v", payload["contains_secrets"])
+	}
+	files, ok := payload["config_files"].(map[string]any)
+	if !ok {
+		t.Fatalf("config_files is not an object: %#v", payload["config_files"])
+	}
+	openAIYAML, _ := files["openai.yaml"].(string)
+	if !strings.Contains(openAIYAML, "api_key: sk-secret") {
+		t.Fatalf("openai config did not preserve secret: %s", openAIYAML)
+	}
+
+	dst := t.TempDir()
+	if err := ImportPackage(ImportOptions{
+		Package:   packagePath,
+		ConfigDir: dst,
+	}); err != nil {
+		t.Fatalf("ImportPackage: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "openai.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile openai.yaml: %v", err)
+	}
+	if string(got) != openAIYAML {
+		t.Fatalf("imported openai.yaml mismatch\ngot:\n%s\nwant:\n%s", got, openAIYAML)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "claude.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("missing source claude.yaml should not be created, err=%v", err)
+	}
+}
+
+func TestImportPackageRejectsUnsafePaths(t *testing.T) {
+	packagePath := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(packagePath, []byte(`{
+  "version": 1,
+  "created_by": "clipal",
+  "contains_secrets": true,
+  "config_files": {
+    "../evil.yaml": "api_key: sk-secret\n"
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile package: %v", err)
+	}
+
+	dst := t.TempDir()
+	err := ImportPackage(ImportOptions{
+		Package:   packagePath,
+		ConfigDir: dst,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsafe") {
+		t.Fatalf("ImportPackage err = %v, want unsafe path error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dst, "evil.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("unsafe file should not be written, stat err=%v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a CLI-only deployment workflow for moving a working Clipal setup to another machine and quickly preparing AI agent CLIs there. This lets users export/import Clipal config without opening the Web UI, then install and optionally apply existing Clipal takeover for selected agents.

## Changes

- Add JSON deploy package export/import commands via `clipal export` and `clipal import <file>`.
- Add `clipal deploy [package] [agent...]` for importing config, installing missing agent CLIs, and applying Clipal takeover.
- Add `clipal install [agent...]` for install-only flows without takeover.
- Support Codex, Claude Code, and Gemini CLI using their official installer commands.
- Document the deploy workflow in English and Chinese.

The existing Clipal provider config schema, routing behavior, Web UI, and takeover implementation are left intact; this PR adds CLI entry points around them.

## Verification

- `go test -count=1 ./...`